### PR TITLE
Add workflow to sync docs to my personal site repository

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,0 +1,33 @@
+# Workflow for syncing docs from this repository to the `josh-wong/josh-wong.github.io` repository
+name: 🔄 Sync versioned docs to my personal site repo
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - docs/**
+      - '!docs/stylesheets/**'
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '0 1 * * 1,4' # Run at 1:00 AM Universal Time Coordinated (UTC) / 10:00 AM Japan Standard Time (JST) on Mondays and Thursdays.
+
+jobs:
+  docs-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Push updated contents in the `docs` folder to the `josh-wong/josh-wong.github.io` repo
+        uses: dmnemec/copy_file_to_another_repo_action@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.SYNC_DOCS_PAT }}
+        with:
+          source_file: "docs/"
+          destination_repo: "josh-wong/josh-wong.github.io"
+          destination_folder: docs/zune-software-setup/
+          destination_branch_create: "zune-software-setup/update-docs"
+          user_name: "josh-wong"
+          user_email: "joshuarwong@gmail.com"
+          commit_message: "AUTO: Sync Zune software setup docs to personal site"
+          use_rsync: rsync -avh


### PR DESCRIPTION
## Description

> Provide a brief description about **why** this PR is necessary. Be sure to provide context.

This PR adds workflow to sync docs to my personal site repository, [josh-wong/josh-wong.github.io](https://github.com/josh-wong/josh-wong.github.io). Instead of having separate a docs site for these personal project docs, having the docs on the same site would provide a better experience. However, I'd like to keep this repository as the single source of truth for now so that the docs are easier to find.

>[!NOTE]
>
> Docs should continue to be updated in this repository. After they are updated, they will automatically sync to [josh-wong/josh-wong.github.io](https://github.com/josh-wong/josh-wong.github.io) by using the workflow introduced in this PR.

## Related issues or PRs

N/A

## Changes made

> Outline the specific changes made in this pull request in the form of a bulleted list. Include relevant details, such as added features, bug fixes, code refactoring, or improvements.

- Created a workflow to sync docs in the `docs/` folder while excluding the `docs/stylesheets/` folder, which contains styles for Material for MkDocs static site generator.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR, add `N/A` after each item.

### Documentation

- [ ] I have updated the side navigation as necessary. `N/A`
- [ ] I have updated the documentation to reflect the changes. `N/A`
- [ ] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [ ] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have checked that my documentation looks as expected on a locally built version of the docs site. `N/A`
- [ ] My changes generate no new warnings. `N/A`

